### PR TITLE
Fix community sample capitalization

### DIFF
--- a/components/mindstorms-ev3/pom.xml
+++ b/components/mindstorms-ev3/pom.xml
@@ -11,7 +11,7 @@
     <packaging>ep-eventflow-fragment</packaging>
     <version>0.0.1-SNAPSHOT</version>
     <name>LEGO MINDSTORMS EV3</name>
-    <description>StreamBase adapters for LEGO MINDSTORMS EV3 robots.</description>
+    <description>StreamBase adapters for LEGO MINDSTORMS EV3 robots</description>
     
     <licenses>
 	    <license>

--- a/components/mindstorms-ev3/pom.xml
+++ b/components/mindstorms-ev3/pom.xml
@@ -10,8 +10,8 @@
     <artifactId>mindstorms-ev3</artifactId>
     <packaging>ep-eventflow-fragment</packaging>
     <version>0.0.1-SNAPSHOT</version>
-    <name>mindstorms-ev3</name>
-    <description></description>
+    <name>LEGO MINDSTORMS EV3</name>
+    <description>StreamBase adapters for LEGO MINDSTORMS EV3 robots.</description>
     
     <licenses>
 	    <license>

--- a/components/uxadmin/pom.xml
+++ b/components/uxadmin/pom.xml
@@ -6,7 +6,7 @@
 	<artifactId>uxadmin</artifactId>
 	<packaging>jar</packaging>
 	<version>0.2</version>
-	<name>uxadmin</name>
+	<name>UXAdmin</name>
 	<description>A simple wrapper around epadmin to provide a nicer ux for common development workflows.</description>
 	<build>
 		<sourceDirectory>src</sourceDirectory>

--- a/components/uxadmin/pom.xml
+++ b/components/uxadmin/pom.xml
@@ -7,7 +7,7 @@
 	<packaging>jar</packaging>
 	<version>0.2</version>
 	<name>UXAdmin</name>
-	<description>A simple wrapper around epadmin to provide a nicer ux for common development workflows.</description>
+	<description>A simple wrapper around epadmin to provide a nicer ux for common development workflows</description>
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>


### PR DESCRIPTION
Community samples were not showing up in alphabetical order in Studio (see SB-51118). The <name> in pom.xml needs to start with an uppercase letter so the capitalization works.